### PR TITLE
Invite actions

### DIFF
--- a/cypress/cypress.config.js
+++ b/cypress/cypress.config.js
@@ -1,4 +1,5 @@
-export default {
+// cypress.config.js
+module.exports = {
   e2e: {
     baseUrl: process.env.CYPRESS_baseUrl || 'http://localhost:3000',
     specPattern: 'e2e/**/*.cy.js',

--- a/cypress/e2e/example.cy.js
+++ b/cypress/e2e/example.cy.js
@@ -1,0 +1,14 @@
+// e2e/example.cy.js
+
+describe('My First Test', () => {
+  it('visits the app and checks the title', () => {
+    // Visit your app (baseUrl is automatically prepended)
+    cy.visit('/');
+
+    // Assert that the page contains expected text
+    cy.contains('Welcome').should('be.visible');
+
+    // Example: check the document title
+    cy.title().should('include', 'My App');
+  });
+});

--- a/pong-backend/src/events/EventsBus.ts
+++ b/pong-backend/src/events/EventsBus.ts
@@ -30,11 +30,6 @@ class EventBus<Events extends Record<string, any>> {
             matchesModel.saveMatch(matchId, player1, player2, score1, score2);
         });
 
-        this.on('friend:add', (data) => {
-            const { userId, friendId } = data;
-            console.log(`User ${userId} added friend ${friendId}`);
-        });
-
         this.on('game:start', (data) => {
 
             const newMatch = new PingPong(data.matchId);

--- a/pong-backend/src/routes/avatar.ts
+++ b/pong-backend/src/routes/avatar.ts
@@ -2,11 +2,11 @@ import { FastifyInstance } from 'fastify';
 import db from '../../database/db.js'
 import fs from "fs";
 import path from "path";
-import fastifyMultipart from "@fastify/multipart";
+//import fastifyMultipart from "@fastify/multipart";
 
 export default function avatarRoute(fastify: FastifyInstance) 
 {
-  fastify.register(fastifyMultipart);
+  //fastify.register(fastifyMultipart);
 
   fastify.post('/avatar', {
     preHandler: [fastify.authenticate],

--- a/pong-backend/src/routes/match.ts
+++ b/pong-backend/src/routes/match.ts
@@ -163,11 +163,13 @@ class MatchesService {
 		const getUser = connectedRoomInstance.getById(userId);
 		if (getUser === undefined) throw new Error("disconnected");
 
-		if (getUser.status !== "CONNECT_ROOM") {
-			return { message: "error", data: "subscribed to a match/tournament" };
+		if (getUser.status !== "MATCH_INVITE") {
+			return { message: "error", data: `subscribed to ${getUser.status}` };
 		}
 
 		const nexMatch = inviteMatchesQueue.get(matchId);
+		
+		inviteMatchesQueue.delete(matchId);
 
 		if (nexMatch === undefined) {
 			return { message: "error", data: "match not find" };

--- a/pong-backend/src/routes/match.ts
+++ b/pong-backend/src/routes/match.ts
@@ -62,7 +62,7 @@ const matchesRoute = (fastify: FastifyInstance) => {
 				},
 			},
 		},
-		handler: matcherController.denyMatchInvite.bind(matcherController),
+		handler: matcherController.matchRemove.bind(matcherController),
 	});
 
 	fastify.post("/match-create", {
@@ -104,11 +104,11 @@ class MatcherController {
 		return res.code(statusCode("OK")).send({ message, data });
 	}
 
-	denyMatchInvite(req: FastifyRequest, res: FastifyReply) {
+	matchRemove(req: FastifyRequest, res: FastifyReply) {
 		const { id } = req.user;
 		const { matchId } = req.query;
 
-		const { message, data } = this.matchesService.denyMatchInvite(matchId, id);
+		const { message, data } = this.matchesService.matchRemove(matchId, id);
 		return res.code(statusCode("OK")).send({ message, data });
 	}
 
@@ -252,10 +252,10 @@ class MatchesService {
 		};
 	}
 
-	denyMatchInvite(matchId: string, userId: number) {
+	matchRemove(matchId: string, userId: number) {
 		const match = inviteMatchesQueue.get(matchId);
 		if (match === undefined) {
-			return { message: "success", data: "match not found" };
+			return { message: "error", data: "match not found" };
 		}
 
 		for (const matchUser of [match.from, match.to]) {
@@ -275,18 +275,28 @@ class MatchesService {
 				);
 			}
 		}
-		inviteMatchesQueue.delete(matchId);
-		return { message: "success", data: "invitation canceled" };
+		if (inviteMatchesQueue.delete(matchId)) {
+			return { message: "success", data: "invitation canceled" };
+		}
+
+		return { message: "error", data: "unable to cancel invitation" };
 	}
 
 	sendMatchInvite(id: number, invitedId: number, settings: {}) {
+		const connected = connectedRoomInstance.getById(id);
+		if (connected === undefined) {
+			return { message: "error", data: "user disconnected" };
+		}
+
+		const matchId = crypto.randomUUID();
+
 		const newMatch: NewInviteMatch = {
-			players: [id],
+			players: [{ id: id, username: connected.username }],
+			matchId,
 			from: id,
 			to: invitedId,
 			settings: settings,
 		};
-		const matchId = crypto.randomUUID();
 
 		for (const playerId of [invitedId, id]) {
 			let userInstance = connectedRoomInstance.getById(playerId);

--- a/pong-backend/src/server.ts
+++ b/pong-backend/src/server.ts
@@ -11,7 +11,7 @@ import { eventsRoutes } from './routes/events.js';
 import cookie from '@fastify/cookie';
 import { matchesRoute } from './routes/match.js';
 import fastifyMultipart from "@fastify/multipart";
-import fastifyStatic from "@fastify/static";
+//import * as fastifyStatic from "@fastify/static";
 import path from "path";
 import fs from "fs";
 import avatarRoute from './routes/avatar.js';
@@ -93,10 +93,10 @@ fastify.register(jwt, {
 	secret: process.env.JWT_SECRET || 'supersecret'
 });
 
-fastify.register(fastifyStatic, {
-    root: path.join(process.cwd(), "src/images"),
-    prefix: "/images/",
-});
+// fastify.register(fastifyStatic, {
+//     root: path.join(process.cwd(), "src/images"),
+//     prefix: "/images/",
+// });
 
 
 fastify.register(loginRoute);

--- a/pong-backend/src/state/ConnectedRoom.ts
+++ b/pong-backend/src/state/ConnectedRoom.ts
@@ -72,11 +72,12 @@ export class ConnectedRoom {
   disconnect(id: number | bigint) {
     this.dropWebsocket(Number(id));
     this.broadcastFriendStatus(Number(id), true);
-    const getUser = this.getById(id);
-    if (getUser && getUser.matchId) {
-      print("[MATCH_DENY]");
-      const matchId = getUser.matchId;
-      matchServiceInstance.matchRemove(matchId, Number(id));
+    const connected = this.getById(id);
+    if (connected && connected.matchId) {
+      if (connected.status === "SEND_INVITE" || connected.status === "MATCH_INVITE") {
+        const matchId = connected.matchId;
+        matchServiceInstance.matchRemove(matchId, Number(id));
+      }
     }
     this.room.delete(Number(id));
   }

--- a/pong-backend/src/state/ConnectedRoom.ts
+++ b/pong-backend/src/state/ConnectedRoom.ts
@@ -76,7 +76,7 @@ export class ConnectedRoom {
     if (getUser && getUser.matchId) {
       print("[MATCH_DENY]");
       const matchId = getUser.matchId;
-      matchServiceInstance.denyMatchInvite(matchId, Number(id));
+      matchServiceInstance.matchRemove(matchId, Number(id));
     }
     this.room.delete(Number(id));
   }

--- a/pong-frontend/src/components/ChatHeader.ts
+++ b/pong-frontend/src/components/ChatHeader.ts
@@ -1,4 +1,4 @@
-import { newIntraMessage, onStateChange, stateProxyHandler } from "../states/stateProxyHandler";
+import { newIntraMessage, onStateChange, stateProxyHandler, updateIntraMessage } from "../states/stateProxyHandler";
 import { profile } from "../app";
 import { fetchRequest, navigateTo } from "../utils";
 import { EmbeddedButton } from "./EmbeddedButton";
@@ -90,8 +90,9 @@ const inviteUserOnclick = async () => {
 		const getMatch = await fetchRequest(`/match-invite?matchId=${response.data.matchId}`, 'GET', {});
 		if (getMatch.message === "success") {
 			const getTo = stateProxyHandler.serverUsers.find(user => user.id === Number(getMatch.data.to))
-			newIntraMessage(`Invite sento to ${getTo?.name} 
-				${EmbeddedButton(0, 'CANCEL', getMatch.data.matchId, 'decline-match-invite')}`);
+			const idx = newIntraMessage(""); 
+			updateIntraMessage(idx, `Invite sent to ${getTo?.name} 
+				${EmbeddedButton(getMatch.data.matchId, 'CANCEL', `${idx}`, 'cancel-match-invite')}`);
 			stateProxyHandler.state = "SEND_INVITE"
 		}
 	} else if (response.message = 'error') {

--- a/pong-frontend/src/components/ChatIntra.ts
+++ b/pong-frontend/src/components/ChatIntra.ts
@@ -27,6 +27,7 @@ export function SystemMessageChat() {
 		messages.innerHTML = '';
 
 		stateProxyHandler.systemMessages.forEach(msg => {
+			if (msg.message === "") return;
 			const p = document.createElement('p');
 			p.id = `msg-index-${msg.index}`;
 			p.className = "m-2 text-base text-black bg-yellow-100 p-2 rounded w-fit";

--- a/pong-frontend/src/components/EmbeddedButton.ts
+++ b/pong-frontend/src/components/EmbeddedButton.ts
@@ -1,11 +1,14 @@
+import { removeIntraMessage } from "../states/stateProxyHandler";
+import { fetchRequest } from "../utils";
+
 function EmbeddedButton(friendId: number, text: string, eventId: string, id: string): string {
     const btnBg = text === "YES" ? "bg-green-500" : "bg-red-500";
     return (
         `<button
 			id="${id}"
-			data-tagname="${friendId}"
+			data-userid="${friendId}"
 			data-eventid="${eventId}"
-			action="${text === "YES" ? "accept" : "decline"}"
+			data-action="${text === "YES" ? "accept" : "decline"}"
 			class="${btnBg} text-white ml-4 p-1 rounded text-xs"
 		>
 			${text}
@@ -13,4 +16,34 @@ function EmbeddedButton(friendId: number, text: string, eventId: string, id: str
     )
 }
 
-export { EmbeddedButton };
+async function acceptFriendOnClick(button: HTMLButtonElement) {
+	console.log("[ACCEPT FRIEND CLICKED]");
+	const eventId = button.dataset.eventid;
+	const userId = button.dataset.userid;
+
+	let response = await fetchRequest(
+	  "/add-friend",
+	  "POST",
+	  {},
+	  { body: JSON.stringify({ id: userId }) }
+	);
+
+	if (response.message === "success") {
+	  response = await fetchRequest(`/delete-event?eventId=${eventId}`, "DELETE");
+	  if (response.message === "success") {
+		removeIntraMessage(Number(eventId));
+	  }
+	}
+  }
+
+  async function denyFriendOnClick(button: HTMLButtonElement) {
+
+    const eventId = button.dataset.eventid;
+
+    const response = await fetchRequest(`/delete-event?eventId=${eventId}`, "DELETE");
+    if (response.message === "success") {
+      removeIntraMessage(Number(eventId));
+    }
+  }
+
+export { EmbeddedButton, acceptFriendOnClick, denyFriendOnClick };

--- a/pong-frontend/src/events/eventListeners.ts
+++ b/pong-frontend/src/events/eventListeners.ts
@@ -37,6 +37,8 @@ export function eventListeners() {
     const btn = target.closest("button[data-action]");
     if (!btn || !(btn instanceof HTMLButtonElement)) return;
 
+    if (btn.id !== "") return;
+
     const action = btn.dataset.action;
 
     if (action === "accept") {
@@ -56,38 +58,8 @@ export function eventListeners() {
     console.log("Button clicked:", button.id);
 
     switch (button.id) {
-      case "accept-match-invite":
-        {
-          const eventId = button.dataset.eventid;
-          const response = await fetchRequest(
-            `/match-invite-accept?matchId=${eventId}`,
-            "GET",
-            {}
-          );
-          if (response.message === "success") {
-            removeIntraMessage(Number(eventId));
-          }
-        }
-        break;
-      case "decline-match-invite":
-        {
-          const eventId = button.dataset.eventid;
-          const userId = button.dataset.userid;
-          const response = await fetchRequest(
-            `/match-invite?matchId=${userId}`,
-            "DELETE"
-          );
-          if (response.message === "success") {
-            const getMatch = await fetchRequest(
-              `/match-invite?matchId=${userId}`,
-              "GET",
-              {}
-            );
-            if (getMatch.message === "error") {
-              removeIntraMessage(Number(eventId));
-              stateProxyHandler.state = "CONNECT_ROOM";
-            }
-          }
+      case "accept-match-invite": {
+          await onClickAcceptMatchInvite(button);
         }
         break;
       case "btn-block-user":
@@ -153,8 +125,9 @@ export function eventListeners() {
           );
         }
         break;
-      case "cancel-match-invite": 
-        await onClickCancelMatchInviteHandler(button);
+      case "cancel-match-invite": {
+        await onClickCancelMatchInvite(button);
+      }
         break;
       case "btn-friend-list":
         {
@@ -183,7 +156,20 @@ export function eventListeners() {
   });
 }
 
-async function onClickCancelMatchInviteHandler(button: HTMLButtonElement) {
+async function onClickAcceptMatchInvite(button: HTMLButtonElement) {
+  const eventId = button.dataset.eventid;
+  const userId = button.dataset.userid;
+
+  const response = await fetchRequest(
+    `/match-invite-accept?matchId=${userId}`,
+    "GET"
+  );
+  if (response.message === "success") {
+    removeIntraMessage(Number(eventId));
+  }
+}
+
+async function onClickCancelMatchInvite(button: HTMLButtonElement) {
   const eventId = button.dataset.eventid;
   const userId = button.dataset.userid;
 

--- a/pong-frontend/src/events/eventListeners.ts
+++ b/pong-frontend/src/events/eventListeners.ts
@@ -1,5 +1,10 @@
 import { profile } from "../app";
-import { newIntraMessage, removeIntraMessage, stateProxyHandler } from "../states/stateProxyHandler";
+import { acceptFriendOnClick, denyFriendOnClick } from "../components/EmbeddedButton";
+import {
+  newIntraMessage,
+  removeIntraMessage,
+  stateProxyHandler,
+} from "../states/stateProxyHandler";
 import { fetchRequest, renderRoute } from "../utils";
 import { getSocket } from "../websocket";
 import { setupPaddleListeners } from "./paddleListeners";
@@ -24,6 +29,24 @@ export function eventListeners() {
     renderRoute(window.location.pathname);
   });
 
+  document.addEventListener("click", async (event) => {
+    const target = event.target as HTMLElement;
+    const btn = target.closest("button[data-action]");
+    if (!btn || !(btn instanceof HTMLButtonElement)) return;
+
+    const action = btn.dataset.action;
+
+    if (action === "accept") {
+      await acceptFriendOnClick(btn);
+    }
+
+    if (action === "decline") {
+      await denyFriendOnClick(btn);
+    }
+
+
+  });
+
   // Add event to btn #chat-select-chat
   document.addEventListener("click", async (event) => {
     const target = event.target as HTMLButtonElement;
@@ -32,65 +55,77 @@ export function eventListeners() {
     console.log("Button clicked:", button.id);
 
     switch (button.id) {
-      case "accept-match-invite": {
-        const eventId = button.dataset.eventid;
-        const response = await fetchRequest(`/match-invite-accept?matchId=${eventId}`, 'GET', {});
-        if (response.message === 'success') {
-          removeIntraMessage(Number(eventId));
-        }
-      }
-      break;
-      case "decline-match-invite": {
-        const eventId = button.dataset.eventid;
-        const response = await fetchRequest(
-          `/match-invite?matchId=${eventId}`,
-          'DELETE')
-        if (response.message === 'success') {
-          const getMatch = await fetchRequest(`/match-invite?matchId=${eventId}`, 'GET', {});
-          if (getMatch.message === 'error') {
-            console.log("[DELETE MESSAGE]", button);
-            const parentMsg = button.closest("p");
-            if (parentMsg) {
-              const tagId = parentMsg.id.replace("msg-index-", "");
-              parentMsg.remove();
-              removeIntraMessage(Number(tagId));
-            }
-            stateProxyHandler.state = "CONNECT_ROOM"
-          }
-        }
-      }
-        break;
-      case "btn-block-user": {
-        const response = await fetchRequest(`/add-block`, "POST", {},
-          {
-            body: JSON.stringify({
-              id: stateProxyHandler.selectChat.id,
-            }),
-          }
-        );
-
-        if (response.message === "success") {
-          newIntraMessage(
-            `User ${stateProxyHandler.selectChat.name} has been blocked.`
+      case "accept-match-invite":
+        {
+          const eventId = button.dataset.eventid;
+          const response = await fetchRequest(
+            `/match-invite-accept?matchId=${eventId}`,
+            "GET",
+            {}
           );
-          await fetchRequest('/block-list', 'GET', {}).then((data) => {
-            if (data.message === 'success') {
-              stateProxyHandler.chatBlockList = data.payload;
-            }
-          });
+          if (response.message === "success") {
+            removeIntraMessage(Number(eventId));
+          }
         }
-      }
-        break
+        break;
+      case "decline-match-invite":
+        {
+          const eventId = button.dataset.eventid;
+          const userId = button.dataset.userid;
+          const response = await fetchRequest(
+            `/match-invite?matchId=${userId}`,
+            "DELETE"
+          );
+          if (response.message === "success") {
+            const getMatch = await fetchRequest(
+              `/match-invite?matchId=${userId}`, "GET", {}
+            );
+            if (getMatch.message === "error") {
+              removeIntraMessage(Number(eventId));
+              stateProxyHandler.state = "CONNECT_ROOM";
+            }
+          }
+        }
+        break;
+      case "btn-block-user":
+        {
+          const response = await fetchRequest(
+            `/add-block`,
+            "POST",
+            {},
+            {
+              body: JSON.stringify({
+                id: stateProxyHandler.selectChat.id,
+              }),
+            }
+          );
+
+          if (response.message === "success") {
+            newIntraMessage(
+              `User ${stateProxyHandler.selectChat.name} has been blocked.`
+            );
+            await fetchRequest("/block-list", "GET", {}).then((data) => {
+              if (data.message === "success") {
+                stateProxyHandler.chatBlockList = data.payload;
+              }
+            });
+          }
+        }
+        break;
       case "btn-unblock-user":
         {
-          const response = await fetchRequest(`/remove-block?id=${stateProxyHandler.selectChat.id}`, "DELETE", {});
+          const response = await fetchRequest(
+            `/remove-block?id=${stateProxyHandler.selectChat.id}`,
+            "DELETE",
+            {}
+          );
 
           if (response.message === "success") {
             newIntraMessage(
               `User ${stateProxyHandler.selectChat.name} has been unblocked.`
             );
-            await fetchRequest('/block-list', 'GET', {}).then((data) => {
-              if (data.message === 'success') {
+            await fetchRequest("/block-list", "GET", {}).then((data) => {
+              if (data.message === "success") {
                 stateProxyHandler.chatBlockList = data.payload;
               }
             });
@@ -108,41 +143,20 @@ export function eventListeners() {
           buttons.forEach((button) => {
             button.classList.remove("bg-gray-100");
           });
-          Array.from(document.getElementsByClassName(chatName)).forEach((elem) => {
-            elem.classList.add("bg-gray-100");
-          });
+          Array.from(document.getElementsByClassName(chatName)).forEach(
+            (elem) => {
+              elem.classList.add("bg-gray-100");
+            }
+          );
         }
         break;
-      case "friend-request":
-        {
-		  const tagName = button.dataset.tagname;
-          const eventId = button.dataset.eventid;
-          const action = button.getAttribute("action");
-
-          if (action === "accept") {
-            const response = await fetchRequest('/add-friend', 'POST', {},
-              { body: JSON.stringify({ id: tagName }) })
-            if (response.message === "success") {
-              await fetchRequest(`/delete-event?eventId=${eventId}`, 'DELETE');
-            }
-          }
-
-          if (action === "decline") {
-            await fetchRequest(`/delete-event?eventId=${eventId}`, 'DELETE');
-          }
-
-          const parentMsg = button.closest("p");
-            if (parentMsg) {
-              const tagId = parentMsg.id.replace("friend-request-", "");
-              parentMsg.remove();
-              removeIntraMessage(Number(tagId));
-            }
-
-        }
-        break;
+      case "cancel-match-invite":
       case "btn-friend-list":
         {
-          var response = await fetchRequest(`/add-event`, "POST", {},
+          var response = await fetchRequest(
+            `/add-event`,
+            "POST",
+            {},
             {
               body: JSON.stringify({
                 to_id: stateProxyHandler.selectChat.id,
@@ -153,7 +167,7 @@ export function eventListeners() {
             }
           );
 
-          if (response.status === "success") {
+          if (response.message === "success") {
             newIntraMessage(
               `Friend request sent to ${stateProxyHandler.selectChat.name}`
             );

--- a/pong-frontend/src/events/eventListeners.ts
+++ b/pong-frontend/src/events/eventListeners.ts
@@ -1,5 +1,8 @@
 import { profile } from "../app";
-import { acceptFriendOnClick, denyFriendOnClick } from "../components/EmbeddedButton";
+import {
+  acceptFriendOnClick,
+  denyFriendOnClick,
+} from "../components/EmbeddedButton";
 import {
   newIntraMessage,
   removeIntraMessage,
@@ -43,8 +46,6 @@ export function eventListeners() {
     if (action === "decline") {
       await denyFriendOnClick(btn);
     }
-
-
   });
 
   // Add event to btn #chat-select-chat
@@ -78,7 +79,9 @@ export function eventListeners() {
           );
           if (response.message === "success") {
             const getMatch = await fetchRequest(
-              `/match-invite?matchId=${userId}`, "GET", {}
+              `/match-invite?matchId=${userId}`,
+              "GET",
+              {}
             );
             if (getMatch.message === "error") {
               removeIntraMessage(Number(eventId));
@@ -150,7 +153,9 @@ export function eventListeners() {
           );
         }
         break;
-      case "cancel-match-invite":
+      case "cancel-match-invite": 
+        await onClickCancelMatchInviteHandler(button);
+        break;
       case "btn-friend-list":
         {
           var response = await fetchRequest(
@@ -176,4 +181,17 @@ export function eventListeners() {
         break;
     }
   });
+}
+
+async function onClickCancelMatchInviteHandler(button: HTMLButtonElement) {
+  const eventId = button.dataset.eventid;
+  const userId = button.dataset.userid;
+
+  const response = await fetchRequest(
+    `/match-invite?matchId=${userId}`,
+    "DELETE"
+  );
+  if (response.message === "success") {
+    removeIntraMessage(Number(eventId));
+  }
 }

--- a/pong-frontend/src/states/stateProxyHandler.ts
+++ b/pong-frontend/src/states/stateProxyHandler.ts
@@ -2,11 +2,21 @@ import { profile } from "../app";
 import type { ChatMessage } from "../interface/ChatMessage";
 import { navigateTo, setTime } from "../utils";
 
-export function newIntraMessage(message: string) {
+export function newIntraMessage(message: string): number {
     stateProxyHandler.systemMessages = [...stateProxyHandler.systemMessages, {
         message: message,
         index: (stateProxyHandler.systemMessages.length),
     }];
+    return stateProxyHandler.systemMessages.length - 1;
+}
+
+export function updateIntraMessage(idx: number, newMessage: string) {
+    stateProxyHandler.systemMessages = stateProxyHandler.systemMessages.map(msg => {
+        if (msg.index === idx) {
+            return { ...msg, message: newMessage };
+        }
+        return msg;
+    });
 }
 
 export function removeIntraMessage(tagId: number) {

--- a/pong-frontend/src/states/stateProxyHandler.ts
+++ b/pong-frontend/src/states/stateProxyHandler.ts
@@ -20,8 +20,13 @@ export function updateIntraMessage(idx: number, newMessage: string) {
 }
 
 export function removeIntraMessage(tagId: number) {
-    stateProxyHandler.systemMessages = stateProxyHandler
-        .systemMessages.filter(msg => msg.index !== Number(tagId));
+    // Update message to "" by index
+    stateProxyHandler.systemMessages = stateProxyHandler.systemMessages.map(msg => {
+        if (msg.index === tagId) {
+            return { ...msg, message: "" };
+        }
+        return msg;
+    });
 }
 
 export function findIntraMessage(tagId: string) {

--- a/pong-frontend/src/websocket/websocketNewEvents.ts
+++ b/pong-frontend/src/websocket/websocketNewEvents.ts
@@ -4,9 +4,9 @@ import { fetchRequest } from "../utils";
 
 
 async function websocketNewEvents() {
-	const { status, data } = await fetchRequest('/to-events', 'GET');
+	const { message, data } = await fetchRequest('/to-events', 'GET');
 	console.log('Fetch New-Events: ', data);
-	if (status === 'success') {
+	if (message === 'success') {
 		for (const event of data) {
 
 			const { type, from_id, id: eventId } = event;
@@ -16,17 +16,29 @@ async function websocketNewEvents() {
 					const getSender = stateProxyHandler.serverUsers
 						.find(({ id }) => Number(id) === Number(from_id));
 					if (getSender === undefined) break;
-					newIntraMessage(
-						`${getSender.name} has send a friend request
-							 	${EmbeddedButton(getSender.id, "YES", `friend-request-${eventId}`, "friend-request")}
-							 		${EmbeddedButton(getSender.id, "NO", `friend-request-${eventId}`, "friend-request")}`
+
+					
+					const idx = newIntraMessage(
+						`${getSender.name} has send a friend request`
 					);
+					
+					const acceptBtn = EmbeddedButton(getSender.id, "YES", `${idx}`, "");
+					const denyBtn = EmbeddedButton(getSender.id, "NO", `${idx}`, "");
+
+					stateProxyHandler.systemMessages = [...stateProxyHandler.systemMessages.slice(0, -1), {
+						message: `${stateProxyHandler.systemMessages[stateProxyHandler.systemMessages.length - 1].message}
+						${acceptBtn} ${denyBtn}`,
+						index: idx,
+					}];
+					break;
+				default:
+
 					break;
 			}
 		}
-		return { status: 'success', data: data.id };
+		return { message: 'success', data: data.id };
 	}
-	return { status: 'error', data: -1 };
+	return { message: 'error', data: -1 };
 }
 
 export { websocketNewEvents };

--- a/pong-frontend/src/websocket/websocketReceiver.ts
+++ b/pong-frontend/src/websocket/websocketReceiver.ts
@@ -118,6 +118,7 @@ export async function websocketReceiver(socket: WebSocket) {
         updateIntraMessage(idx, `You have received a game invite from ${getName}.
           ${EmbeddedButton(data.payload.matchId, "YES", `${idx}`, "accept-match-invite")}
           ${EmbeddedButton(data.payload.matchId, "NO", `${idx}`, "cancel-match-invite")}`);
+        stateProxyHandler.state = "MATCH_INVITE";
         break;
       }
       case "MATCH_DECLINED": {

--- a/pong-frontend/src/websocket/websocketReceiver.ts
+++ b/pong-frontend/src/websocket/websocketReceiver.ts
@@ -6,6 +6,7 @@ import {
   newIntraMessage,
   stateProxyHandler,
   findIntraMessage,
+  updateIntraMessage,
 } from "../states/stateProxyHandler";
 import { serverState } from "../states/serverState";
 import { websocketNewEvents } from "./websocketNewEvents";
@@ -113,10 +114,10 @@ export async function websocketReceiver(socket: WebSocket) {
         const getName = stateProxyHandler.serverUsers.find(
           (user) => user.id === data.payload.from
         )?.name;
-        newIntraMessage(`You have received a game invite from ${getName}.
-          ${EmbeddedButton(0, "YES", data.payload.matchId, "accept-match-invite")}
-          ${EmbeddedButton(0, "NO", data.payload.matchId, "decline-match-invite")}`);
-        stateProxyHandler.state = "MATCH_INVITE";
+        const idx = newIntraMessage("");
+        updateIntraMessage(idx, `You have received a game invite from ${getName}.
+          ${EmbeddedButton(data.payload.matchId, "YES", `${idx}`, "accept-match-invite")}
+          ${EmbeddedButton(data.payload.matchId, "NO", `${idx}`, "cancel-match-invite")}`);
         break;
       }
       case "MATCH_DECLINED": {

--- a/pong-frontend/src/websocket/websocketReceiver.ts
+++ b/pong-frontend/src/websocket/websocketReceiver.ts
@@ -52,7 +52,7 @@ export async function websocketReceiver(socket: WebSocket) {
           // Get the sender id by filter out my own id
           const sender = data.sender.find((sid: number) => sid !== profile.id);
           if (!sender) return;
-		  console.log("[WEBSOCKET RECEIVER] CHAT_MESSAGE from ", data.history);
+          console.log("[WEBSOCKET RECEIVER] CHAT_MESSAGE from ", data.history);
           stateProxyHandler.messages.set(sender, data.history);
           stateProxyHandler.state = data.message;
         }
@@ -109,17 +109,18 @@ export async function websocketReceiver(socket: WebSocket) {
         stateProxyHandler.availableMatches = data.payload.matches;
         break;
       }
-      case "MATCH_INVITE":
-        let getName = stateProxyHandler.serverUsers.find(
+      case "MATCH_INVITE": {
+        const getName = stateProxyHandler.serverUsers.find(
           (user) => user.id === data.payload.from
         )?.name;
         newIntraMessage(`You have received a game invite from ${getName}.
-				${EmbeddedButton(0, "YES", data.payload.matchId, "accept-match-invite")}
-				${EmbeddedButton(0, "NO", data.payload.matchId, "decline-match-invite")}`);
+          ${EmbeddedButton(0, "YES", data.payload.matchId, "accept-match-invite")}
+          ${EmbeddedButton(0, "NO", data.payload.matchId, "decline-match-invite")}`);
         stateProxyHandler.state = "MATCH_INVITE";
         break;
-      case "MATCH_DECLINED":
-        getName = stateProxyHandler.serverUsers.find(
+      }
+      case "MATCH_DECLINED": {
+        const getName = stateProxyHandler.serverUsers.find(
           (user) => user.id === data.payload.from
         )?.name;
         newIntraMessage(`invitation canceled by ${getName}`);
@@ -130,6 +131,7 @@ export async function websocketReceiver(socket: WebSocket) {
           removeIntraMessage(idx);
         }
         stateProxyHandler.state = "CONNECT_ROOM";
+      }
     }
   });
 }


### PR DESCRIPTION
This pull request introduces several improvements and refactors across the backend and Cypress test setup. The main changes include a significant refactor of the `PingPong` class for clearer naming and logging, a standardization of API response property names from `status` to `message` in event and friend routes, and initial setup for Cypress end-to-end testing.

### Backend Refactors and Improvements

**PingPong Class Refactor:**
- Renamed the `playersIds` map to `playerConnectionInfo` throughout the `PingPong` class for clarity, and updated all usages accordingly. Also, the method `getPlayer` was renamed to `getPlayerFromConnectedRoom`, with added debug logging. [[1]]

**API Response Standardization:**
- Changed API response objects in event and friend routes to use the `message` property instead of `status`, affecting types and all related logic in `events.ts` and `friend.ts`. This brings consistency to response formats. 
**Code Cleanup:**
- Removed an unused event handler for `friend:add` in the `EventsBus` class.
- Commented out the unused `fastifyMultipart` import and registration in the avatar route, possibly to resolve a dependency or middleware issue.

### Cypress Test Setup

**Initial Cypress Configuration and Example Test:**
- Converted `cypress.config.js` from ES module to CommonJS export for compatibility.
- Added a sample end-to-end test in `cypress/e2e/example.cy.js` to verify the app loads and displays the expected title and welcome message.

### Dependency and Import Adjustments

- Removed an unused import of `EventsService` from the friend route.

These changes improve code clarity, maintainability, and testability, while also unifying API response structures across the backend.