### PR TITLE
Profile button

### DIFF
--- a/pong-backend/src/routes/tournament.ts
+++ b/pong-backend/src/routes/tournament.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
 import { connectedRoomInstance } from "../state/ConnectedRoom.js";
-import { joinTournamentQueue } from "../state/tournamentRoom.js";
+import { joinTournamentQueue, tournamentQueue } from "../state/tournamentRoom.js";
 
 const tournamentsRoute = (fastify: FastifyInstance) => {
 	const  tournamentController = new TournamentController();
@@ -8,6 +8,11 @@ const tournamentsRoute = (fastify: FastifyInstance) => {
 		preHandler: [fastify.authenticate],
 		handler: tournamentController.joinTournament.bind(tournamentController)
 	})
+
+	fastify.get("/tournament/quit", {
+		preHandler: [fastify.authenticate],
+		handler: tournamentController.quitTournament.bind(tournamentController)
+	});
 }
 
 class TournamentController {
@@ -20,9 +25,38 @@ class TournamentController {
 
 		return res.status(200).send({ message, data });
 	}
+
+	quitTournament(req: FastifyRequest, res: FastifyReply) {
+		const userId = req.userId;
+		const { message, data } = this.tournamentService.quitTournament(Number(userId));
+
+		return res.status(200).send({ message, data });
+	}
 }
 
 class TournamentService {
+
+	quitTournament(userId: number) {
+		const isConnectedAtQueue = tournamentQueue.has(userId);
+
+		if (isConnectedAtQueue) {
+			tournamentQueue.delete(userId);
+		}
+
+		const connected = connectedRoomInstance.getById(userId);
+
+		if (connected === undefined) {
+			return { message: "error", data: "disconnected" };
+		}
+
+		connected.status = "CONNECT_ROOM";
+		// Send back to CONNECT_ROOM
+		connectedRoomInstance.sendWebsocketMessage(connected.id, "CONNECT_ROOM");
+
+		return { message: "success", data: "left tournament" };
+
+	}
+
 	joinTournament(userId: number) {
 
 		const connected = connectedRoomInstance.getById(userId);

--- a/pong-frontend/postcss.config.js
+++ b/pong-frontend/postcss.config.js
@@ -1,7 +1,7 @@
-export default {
-  plugins: {
-    '@tailwindcss/postcss': {},
-    autoprefixer: {},
-  },
-}
+// export default {
+//   plugins: {
+//     '@tailwindcss/postcss': {},
+//     autoprefixer: {},
+//   },
+// }
 

--- a/pong-frontend/src/components/Alert.ts
+++ b/pong-frontend/src/components/Alert.ts
@@ -19,7 +19,6 @@ export class Alert {
       "game-font ",
       "relative",
       "p-6",
-      "max-w-lg",
       "w-[90%]",
       "text-center",
       "rounded-lg",

--- a/pong-frontend/src/components/ChatSendInput.ts
+++ b/pong-frontend/src/components/ChatSendInput.ts
@@ -1,44 +1,54 @@
-import { stateProxyHandler } from "../states/stateProxyHandler";
+import { profile } from "../app";
+import { onStateChange, stateProxyHandler } from "../states/stateProxyHandler";
 import { websocketChatSend } from "../websocket/websocketChatSend";
 import { FancyButton } from "./Button";
 
 export function ChatSendInput(): HTMLDivElement {
     const inputDiv = document.createElement("div");
     inputDiv.id = "chat-send-container";
-    inputDiv.className = "flex items-center p-2 bg-[#36393e] border-t border-[rgb(66,69,73)]";
+    inputDiv.className = "flex items-center min-w-[420px] p-2 bg-[#36393e] border-t border-[rgb(66,69,73)]";
 
-    const form = document.createElement("form");
-    form.className = "flex w-full gap-2";
-
-    const input = document.createElement("input");
-    input.id = "chat-input";
-    input.type = "text";
-    input.placeholder = "Type a message...";
-    input.className = `
+    
+    function onRender() {
+        inputDiv.innerHTML = "";
+        const isChatSelected = stateProxyHandler.selectChat.id === profile.id;;
+        if (isChatSelected) {
+            return;
+        }
+        const form = document.createElement("form");
+        form.className = "flex w-full gap-2";
+        // Any dynamic rendering logic can go here
+        const input = document.createElement("input");
+        input.id = "chat-input";
+        input.type = "text";
+        input.placeholder = "Type a message...";
+        input.className = `
         flex-grow px-3 py-2 rounded-md
         bg-[#424549]
         text-white placeholder:text-gray-400
         border border-[#424549]
         focus:outline-none focus:ring-2 focus:ring-[rgb(255,80,80)] focus:border-[rgb(255,80,80)]
-    `;
-
-    const sendBtn = FancyButton("Send", "h-14 w-30 tracking-widest text-lg mt-1", () => { });
-    sendBtn.id = "send-chat-btn";
-
-    form.appendChild(input);
-    form.appendChild(sendBtn);
-
-    inputDiv.appendChild(form);
-
-    form.onsubmit = (event) => {
-        event.preventDefault();
-        const message = input.value.trim();
-        if (message) {
-            const {name, id} = stateProxyHandler.selectChat;
-            websocketChatSend(message, name, id);
-            input.value = "";
+        `;
+        
+        const sendBtn = FancyButton("Send", "h-14 w-30 tracking-widest text-lg mt-1", () => { });
+        sendBtn.id = "send-chat-btn";
+        
+        form.appendChild(input);
+        form.appendChild(sendBtn);
+        
+        inputDiv.appendChild(form);
+        
+        form.onsubmit = (event) => {
+            event.preventDefault();
+            const message = input.value.trim();
+            if (message) {
+                const {name, id} = stateProxyHandler.selectChat;
+                websocketChatSend(message, name, id);
+                input.value = "";
+            }
         }
     }
-
+    onRender();
+    onStateChange("selectChat", onRender);
     return inputDiv;
 }

--- a/pong-frontend/src/components/ProfileContainer.ts
+++ b/pong-frontend/src/components/ProfileContainer.ts
@@ -50,6 +50,15 @@ function addFriendButton(): string {
 	}
 }
 
+function updateProfileButton(): string {
+	return `
+		<button id="update-profile"
+			class="border-2 border-black p-6 rounded hover:bg-blue-300">
+			UPDATE PROFILE
+		</button>
+		`;
+}
+
 export function ProfileContainer() {
 	const mainDiv = document.createElement("div");
 
@@ -78,6 +87,7 @@ export function ProfileContainer() {
 					<div class="flex flex-col gap-2 w-40 h-40">
 						${ isUserProfile ? "" : addFriendButton()}
 						${ isUserProfile ? "" : BlockButton()}
+						${ isUserProfile ? updateProfileButton() : "" }
 					</div>
 				</div>
 

--- a/pong-frontend/src/components/ProfileLogoutButton.ts
+++ b/pong-frontend/src/components/ProfileLogoutButton.ts
@@ -2,7 +2,7 @@ export function ProfileLogoutButton() {;
   return `
 <div class="p-4 flex justify-around items-center w-full">
   <button 
-  id="profile-btn" 
+  id="view-profile" 
   class="border-2 border-black p-4 rounded cursor-pointer hover:bg-gray-200">
     PROFILE
   </button>

--- a/pong-frontend/src/components/UsersList.ts
+++ b/pong-frontend/src/components/UsersList.ts
@@ -1,3 +1,4 @@
+import { profile } from "../app";
 import { stateProxyHandler, onMessageChange, type FriendListType, type ServerUsersList } from "../states/stateProxyHandler";
 import { fetchRequest } from "../utils";
 
@@ -29,6 +30,9 @@ export function List(
 
     users.forEach((user) => {
         // Get name form serverUsers
+        if (user.id === profile.id) {
+            return; // Skip current user
+        }
         const serverUSer = stateProxyHandler.serverUsers.find((u) => u.id === user.id);
         const name = serverUSer ? serverUSer.name : "Unknown";
         const btn = document.createElement("button");

--- a/pong-frontend/src/events/eventListeners.ts
+++ b/pong-frontend/src/events/eventListeners.ts
@@ -90,7 +90,11 @@ export function eventListeners() {
 		console.log("Button clicked:", button.id);
 
 		switch (button.id) {
-			case "profile-btn": { await profileOnclick(); }
+			case "update-profile": { await profileOnclick(); }
+				break;
+			case "view-profile": { 
+				stateProxyHandler.selectChat = { name: profile.username, id: profile.id };
+			 }
 				break;
 			case "accept-match-invite": { await onClickAcceptMatchInvite(button); }
 				break;

--- a/pong-frontend/src/events/eventListeners.ts
+++ b/pong-frontend/src/events/eventListeners.ts
@@ -128,6 +128,8 @@ export function eventListeners() {
 				break;
 			case "tournament-btn": { await joinTournament(); }
 				break;
+			case "btn-leave-tournament": { await leaveTournament(button); }
+				break;
 			case "match-btn": {
 				const socket = getSocket();
 				if (!socket) return;
@@ -220,6 +222,20 @@ async function joinTournament() {
 	if (response.message === "error") {
 		const alert = new Alert(`${response.data}`);
 		alert.show();
+	}
+}
+
+async function leaveTournament(button: HTMLButtonElement) {
+	const eventId = button.dataset.eventindex;
+	console.log("EVENT ID LEAVE TOURNEY =", eventId);
+	const response = await fetchRequest(
+		`/tournament/quit`,
+		"GET"
+	);
+
+	if (response.message === "success") {
+		newIntraMessage(`You have left the tournament room.`);
+		removeIntraMessage(Number(eventId));
 	}
 }
 

--- a/pong-frontend/src/states/stateProxyHandler.ts
+++ b/pong-frontend/src/states/stateProxyHandler.ts
@@ -20,10 +20,10 @@ export function updateIntraMessage(idx: number, newMessage: string) {
     });
 }
 
-export function removeIntraMessage(tagId: number) {
+export function removeIntraMessage(idx: number) {
     // Update message to "" by index
     stateProxyHandler.systemMessages = stateProxyHandler.systemMessages.map(msg => {
-        if (msg.index === tagId) {
+        if (msg.index === idx) {
             return { ...msg, message: "" };
         }
         return msg;

--- a/pong-frontend/src/websocket/websocketReceiver.ts
+++ b/pong-frontend/src/websocket/websocketReceiver.ts
@@ -41,7 +41,18 @@ export async function websocketReceiver(socket: WebSocket) {
         break;
       case "TOURNAMENT_ROOM":
         stateProxyHandler.state = data.message;
-        newIntraMessage(`You have joined the tournament room.`);
+        const idx = newIntraMessage("");
+        updateIntraMessage(
+          idx,
+          `You have joined the tournament room.
+          <button 
+          class="bg-red-500 text-white ml-4 p-1 rounded text-xs"
+          id="btn-leave-tournament"
+          data-eventindex=${idx}
+          >
+            CANCEL
+          </button>`
+        );
         break;
       case "GAME_OVER":
         newIntraMessage(data.payload.message);
@@ -124,27 +135,41 @@ export async function websocketReceiver(socket: WebSocket) {
           (user) => user.id === data.payload.from
         )?.name;
         const idx = newIntraMessage("");
-        updateIntraMessage(idx, `You have received a game invite from ${getName}.
-          ${EmbeddedButton(data.payload.matchId, "YES", `${idx}`, "accept-match-invite")}
-          ${EmbeddedButton(data.payload.matchId, "NO", `${idx}`, "cancel-match-invite")}`);
+        updateIntraMessage(
+          idx,
+          `You have received a game invite from ${getName}.
+          ${EmbeddedButton(
+            data.payload.matchId,
+            "YES",
+            `${idx}`,
+            "accept-match-invite"
+          )}
+          ${EmbeddedButton(
+            data.payload.matchId,
+            "NO",
+            `${idx}`,
+            "cancel-match-invite"
+          )}`
+        );
         stateProxyHandler.state = "MATCH_INVITE";
         break;
       }
-      case "MATCH_DECLINED": {
-        const getName = stateProxyHandler.serverUsers.find(
-          (user) => user.id === data.payload.from
-        )?.name;
-        newIntraMessage(`invitation canceled by ${getName}`);
-        const idx = stateProxyHandler.systemMessages.findIndex((msg) =>
-          msg.message.includes(`${data.payload.matchId}"`)
-        );
-        if (idx !== -1) {
-          removeIntraMessage(idx);
+      case "MATCH_DECLINED":
+        {
+          const getName = stateProxyHandler.serverUsers.find(
+            (user) => user.id === data.payload.from
+          )?.name;
+          newIntraMessage(`invitation canceled by ${getName}`);
+          const idx = stateProxyHandler.systemMessages.findIndex((msg) =>
+            msg.message.includes(`${data.payload.matchId}"`)
+          );
+          if (idx !== -1) {
+            removeIntraMessage(idx);
+          }
+          stateProxyHandler.state = "CONNECT_ROOM";
         }
-        stateProxyHandler.state = "CONNECT_ROOM";
-      }
         break;
-      case 'intra:message': {
+      case "intra:message": {
         newIntraMessage(data.payload.message);
       }
     }


### PR DESCRIPTION
This pull request introduces a "leave tournament" feature, refines chat and profile UI logic, and improves message handling in both the backend and frontend of the Pong application. The most significant changes include adding backend support for quitting tournaments, updating frontend logic to allow users to leave tournaments via a button, and refining chat and profile UI behavior based on user state.

**Tournament feature enhancements:**
* Added `/tournament/quit` endpoint and supporting logic in `pong-backend/src/routes/tournament.ts` to allow users to leave a tournament queue and reset their room status. [[1]](diffhunk://#diff-24ce1aeb86e77993fe9867720f20636fbb95948362bc017f4649dad000d1b93bL3-R15) [[2]](diffhunk://#diff-24ce1aeb86e77993fe9867720f20636fbb95948362bc017f4649dad000d1b93bR28-R59)
* Implemented frontend leave tournament functionality: when a user joins a tournament, a "CANCEL" button is now shown in the system message, and clicking it triggers the new backend endpoint to leave the tournament. [[1]](diffhunk://#diff-337d86b669d301881c5a9758b3765c57cbf2d76677dbe07309fb3905ba22d153L44-R55) [[2]](diffhunk://#diff-760969b560e4dc09b5cea0f9e8752e73b3c627ecd838fccf24f504ed384b8549R131-R132) [[3]](diffhunk://#diff-760969b560e4dc09b5cea0f9e8752e73b3c627ecd838fccf24f504ed384b8549R228-R241)

**Chat and profile UI improvements:**
* Updated `ChatSendInput` so the chat input is hidden when the user's own chat is selected, and rerenders dynamically on chat selection changes. [[1]](diffhunk://#diff-e03cf4ed29498a2526f2ada36d08596a31d4f76bd9102b47344fdbefbc501996L1-R20) [[2]](diffhunk://#diff-e03cf4ed29498a2526f2ada36d08596a31d4f76bd9102b47344fdbefbc501996L42-R52)
* Added an "UPDATE PROFILE" button to the profile UI when viewing your own profile, and clarified button IDs and event handling for profile-related actions. [[1]](diffhunk://#diff-317f19578bc2a38331fbef3d62814cfb256453452c916ca554d4fda9c47cc02cR53-R61) [[2]](diffhunk://#diff-317f19578bc2a38331fbef3d62814cfb256453452c916ca554d4fda9c47cc02cR90) [[3]](diffhunk://#diff-687111f40764e611cbba46671a76fc232627a31464d29a0f6576cb11fcd9976dL5-R5) [[4]](diffhunk://#diff-760969b560e4dc09b5cea0f9e8752e73b3c627ecd838fccf24f504ed384b8549L93-R97)

**User list and message handling:**
* Modified the users list to exclude the current user from the display, preventing self-interaction. [[1]](diffhunk://#diff-49f48dccc22f5351c574acac7a9d395a631a6d9ff527304fb7dd0b083df84fd9R1) [[2]](diffhunk://#diff-49f48dccc22f5351c574acac7a9d395a631a6d9ff527304fb7dd0b083df84fd9R33-R35)
* Improved system message management by updating and removing messages via index, supporting more dynamic UI feedback. [[1]](diffhunk://#diff-43f5442d13d3633a715cf6ceecb7a2320ab3c7370e6602e84ab9d3b84e3c80f9L23-R26) [[2]](diffhunk://#diff-337d86b669d301881c5a9758b3765c57cbf2d76677dbe07309fb3905ba22d153L127-R158) [[3]](diffhunk://#diff-337d86b669d301881c5a9758b3765c57cbf2d76677dbe07309fb3905ba22d153L147-R172)

Other minor changes include CSS tweaks and configuration comments.